### PR TITLE
Add anticipated s01e01 normal codes

### DIFF
--- a/code_schemes/s01e01.json
+++ b/code_schemes/s01e01.json
@@ -13,6 +13,15 @@
       "VisibleInCoda": true,
       "Shortcut": "e"
     },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
 
     {
       "CodeID": "code-NA-f93d3eb7",
@@ -102,15 +111,6 @@
       "DisplayText": "meta: showtime question",
       "NumericValue": -100030,
       "StringValue": "showtime_question",
-      "VisibleInCoda": true
-    },
-    {
-      "CodeID": "code-Q-a5d3700d",
-      "CodeType": "Meta",
-      "MetaCode": "question",
-      "DisplayText": "meta: question",
-      "NumericValue": -100010,
-      "StringValue": "question",
       "VisibleInCoda": true
     },
     {

--- a/code_schemes/s01e01.json
+++ b/code_schemes/s01e01.json
@@ -20,7 +20,8 @@
       "DisplayText": "meta: question",
       "NumericValue": -100010,
       "StringValue": "question",
-      "VisibleInCoda": true
+      "VisibleInCoda": true,
+      "Shortcut": "q"
     },
     {
       "CodeID": "code-a3233242",
@@ -28,7 +29,8 @@
       "DisplayText": "knowledge",
       "NumericValue": 1,
       "StringValue": "knowledge",
-      "VisibleInCoda": true
+      "VisibleInCoda": true,
+      "Shortcut": "k"
     },
     {
       "CodeID": "code-0d56a58a",
@@ -36,7 +38,8 @@
       "DisplayText": "attitude",
       "NumericValue": 2,
       "StringValue": "attitude",
-      "VisibleInCoda": true
+      "VisibleInCoda": true,
+      "Shortcut": "a"
     },
     {
       "CodeID": "code-8c2a5758",
@@ -44,7 +47,8 @@
       "DisplayText": "behaviour",
       "NumericValue": 3,
       "StringValue": "behaviour",
-      "VisibleInCoda": true
+      "VisibleInCoda": true,
+      "Shortcut": "b"
     },
     {
       "CodeID": "code-NA-f93d3eb7",

--- a/code_schemes/s01e01.json
+++ b/code_schemes/s01e01.json
@@ -22,7 +22,30 @@
       "StringValue": "question",
       "VisibleInCoda": true
     },
-
+    {
+      "CodeID": "code-a3233242",
+      "CodeType": "Normal",
+      "DisplayText": "knowledge",
+      "NumericValue": 1,
+      "StringValue": "knowledge",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-0d56a58a",
+      "CodeType": "Normal",
+      "DisplayText": "attitude",
+      "NumericValue": 2,
+      "StringValue": "attitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-8c2a5758",
+      "CodeType": "Normal",
+      "DisplayText": "behaviour",
+      "NumericValue": 3,
+      "StringValue": "behaviour",
+      "VisibleInCoda": true
+    },
     {
       "CodeID": "code-NA-f93d3eb7",
       "CodeType": "Control",


### PR DESCRIPTION
Adds normal codes "knowledge", "attitude", and "behaviour".

We will hide these codes in the first column in coda to encourage RAs to label with a control/meta code in the first column, but keep them in the scheme so that we don't need to attempt to implement label synchronisation again (as this is very time-consuming to implement and very hard to get right).