### PR TITLE
Rename the Outputs/graphs folder -> Outputs/Automated Analysis

### DIFF
--- a/run_scripts/5_generate_analysis_graphs.sh
+++ b/run_scripts/5_generate_analysis_graphs.sh
@@ -34,4 +34,4 @@ cd ..
 ./docker-run-generate-analysis-graphs.sh ${CPU_PROFILE_ARG} \
   "$USER" "$GOOGLE_CLOUD_CREDENTIALS_FILE_PATH" "$PIPELINE_CONFIGURATION_FILE_PATH" \
   "$DATA_ROOT/Outputs/messages_traced_data.jsonl" "$DATA_ROOT/Outputs/individuals_traced_data.jsonl" \
-  "$DATA_ROOT/Outputs/graphs/"
+  "$DATA_ROOT/Outputs/Automated Analysis/"


### PR DESCRIPTION
Keeping automated analysis CSVs in a folder called graphs is confusing. We'll need to do some other renaming in future as the analysis_graphs stage continues to evolve into an automated_analysis stage, but this covers the worst offender for now.