### PR TITLE
Add graphs disaggregated by gender and a pie of gender; switch to plotly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,20 +38,10 @@ RUN if [ "$INSTALL_MEMORY_PROFILER" = "true" ]; then \
         pip install memory_profiler; \
     fi
 
-#WORKDIR /tmp
-#RUN wget --no-verbose -O orca.AppImage https://github.com/plotly/orca/releases/download/v1.3.0/orca-1.3.0.AppImage
-#RUN chmod +x orca.AppImage
-#RUN ./orca.AppImage --appimage-extract
-#RUN printf '#!/bin/bash \nxvfb-run --auto-servernum --server-args "-screen 0 640x480x24" /tmp/squashfs-root/app/orca "$@"' > /usr/bin/orca
-#RUN chmod -R 777 squashfs-root/
-##RUN chmod +x /usr/bin/orca
-#RUN orca --help
-#RUN chmod +x /tmp/orca.AppImage && ln -s /tmp/orca.AppImage /usr/local/bin/orca
-
-# Plotly depedencies
+# Install plotly depedencies (orca and gcc)
 ARG ORCA_VERSION="1.2.1"
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    apt-get install -y \
         wget \
         xvfb \
         xauth \
@@ -60,7 +50,8 @@ RUN apt-get update && \
         libxss1 \
         libgconf-2-4 \
         libnss3 \
-        libasound2 && \
+        libasound2 \
+        gcc && \
     mkdir -p /opt/orca && \
     cd /opt/orca && \
     wget --no-verbose -O /opt/orca/orca-${ORCA_VERSION}.AppImage https://github.com/plotly/orca/releases/download/v${ORCA_VERSION}/orca-${ORCA_VERSION}-x86_64.AppImage && \
@@ -78,8 +69,6 @@ RUN mkdir /data
 
 # Set working directory
 WORKDIR /app
-
-RUN apt-get install -y gcc
 
 # Install project dependencies.
 ADD Pipfile /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,37 @@ RUN if [ "$INSTALL_MEMORY_PROFILER" = "true" ]; then \
         pip install memory_profiler; \
     fi
 
+#WORKDIR /tmp
+#RUN wget --no-verbose -O orca.AppImage https://github.com/plotly/orca/releases/download/v1.3.0/orca-1.3.0.AppImage
+#RUN chmod +x orca.AppImage
+#RUN ./orca.AppImage --appimage-extract
+#RUN printf '#!/bin/bash \nxvfb-run --auto-servernum --server-args "-screen 0 640x480x24" /tmp/squashfs-root/app/orca "$@"' > /usr/bin/orca
+#RUN chmod -R 777 squashfs-root/
+##RUN chmod +x /usr/bin/orca
+#RUN orca --help
+#RUN chmod +x /tmp/orca.AppImage && ln -s /tmp/orca.AppImage /usr/local/bin/orca
+
+# Plotly depedencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        wget \
+        xvfb \
+        xauth \
+        libgtk2.0-0 \
+        libxtst6 \
+        libxss1 \
+        libgconf-2-4 \
+        libnss3 \
+        libasound2 && \
+    mkdir -p /opt/orca && \
+    cd /opt/orca && \
+    wget --no-verbose https://github.com/plotly/orca/releases/download/v1.2.1/orca-1.2.1-x86_64.AppImage && \
+    chmod +x orca-1.2.1-x86_64.AppImage && \
+    ./orca-1.2.1-x86_64.AppImage --appimage-extract && \
+    rm orca-1.2.1-x86_64.AppImage && \
+    printf '#!/bin/bash \nxvfb-run --auto-servernum --server-args "-screen 0 640x480x24" /opt/orca/squashfs-root/app/orca "$@"' > /usr/bin/orca && \
+    chmod +x /usr/bin/orca
+
 # Make a directory for private credentials files
 RUN mkdir /credentials
 
@@ -46,6 +77,8 @@ RUN mkdir /data
 
 # Set working directory
 WORKDIR /app
+
+RUN apt-get install -y gcc
 
 # Install project dependencies.
 ADD Pipfile /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN if [ "$INSTALL_MEMORY_PROFILER" = "true" ]; then \
 #RUN chmod +x /tmp/orca.AppImage && ln -s /tmp/orca.AppImage /usr/local/bin/orca
 
 # Plotly depedencies
+ARG ORCA_VERSION="1.2.1"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         wget \
@@ -62,10 +63,10 @@ RUN apt-get update && \
         libasound2 && \
     mkdir -p /opt/orca && \
     cd /opt/orca && \
-    wget --no-verbose https://github.com/plotly/orca/releases/download/v1.2.1/orca-1.2.1-x86_64.AppImage && \
-    chmod +x orca-1.2.1-x86_64.AppImage && \
-    ./orca-1.2.1-x86_64.AppImage --appimage-extract && \
-    rm orca-1.2.1-x86_64.AppImage && \
+    wget --no-verbose -O /opt/orca/orca-${ORCA_VERSION}.AppImage https://github.com/plotly/orca/releases/download/v${ORCA_VERSION}/orca-${ORCA_VERSION}-x86_64.AppImage && \
+    chmod +x orca-${ORCA_VERSION}.AppImage && \
+    ./orca-${ORCA_VERSION}.AppImage --appimage-extract && \
+    rm orca-${ORCA_VERSION}.AppImage && \
     printf '#!/bin/bash \nxvfb-run --auto-servernum --server-args "-screen 0 640x480x24" /opt/orca/squashfs-root/app/orca "$@"' > /usr/bin/orca && \
     chmod +x /usr/bin/orca
 

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,9 @@ google-cloud-storage = "*"
 altair = "*"
 selenium = "*"
 pyinstrument = "*"
+plotly = "*"
+requests = "*"
+psutil = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "829ad4aeaf05db517e75fe5d10a4ae469a1550056ba244031553d966f570f779"
+            "sha256": "1edf8064d24019a8d3d5931eb65a383e81cd4e5e26e23d5e28c14593ee1dfd94"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -98,17 +98,17 @@
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:3121d55d106ef1a2756e8074239512055bd99eb44da417b3dd680f9a1385adec",
-                "sha256:a8a88174f66d92aed7ebbd73744c2c319b4b1ce828e565f9ec721352d2e2fb8c"
+                "sha256:0f5b42a14e2d2f7dee40f2e4514531dbe95ebde9c2173b1c4040a65c427e7900",
+                "sha256:5032ad1af5046889649b3848f2e871889fbb6ae440198a549fe1699581300386"
             ],
-            "version": "==1.7.11"
+            "version": "==1.8.0"
         },
         "google-auth": {
             "hashes": [
-                "sha256:1ee22e22f35d6e00f068d7b3999b2ce24ecb5d0dcbd485aa6896d2b83c8907d6",
-                "sha256:28a848d47c55075a0f29d7e26b7a213515c137ab8f0670e546e46d1277060e47"
+                "sha256:4fddaf62bcfc3b9cc1bb2062130937a25ebe781b8eb15beec217c160b8cabb68",
+                "sha256:ec172006e626bb90f6069e9358c373bc991a15da6cc55276986d9ecd29235b15"
             ],
-            "version": "==1.11.2"
+            "version": "==1.11.3"
         },
         "google-auth-httplib2": {
             "hashes": [
@@ -308,29 +308,29 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:1786a08236f2c92ae0e70423c45e1e62788ed33028f94ca99c4df03f5be6b3c6",
-                "sha256:17aa7a81fe7599a10f2b7d95856dc5cf84a4eefa45bc96123cbbc3ebc568994e",
-                "sha256:20b26aaa5b3da029942cdcce719b363dbe58696ad182aff0e5dcb1687ec946dc",
-                "sha256:2d75908ab3ced4223ccba595b48e538afa5ecc37405923d1fea6906d7c3a50bc",
-                "sha256:39d2c685af15d3ce682c99ce5925cc66efc824652e10990d2462dfe9b8918c6a",
-                "sha256:56bc8ded6fcd9adea90f65377438f9fea8c05fcf7c5ba766bef258d0da1554aa",
-                "sha256:590355aeade1a2eaba17617c19edccb7db8d78760175256e3cf94590a1a964f3",
-                "sha256:70a840a26f4e61defa7bdf811d7498a284ced303dfbc35acb7be12a39b2aa121",
-                "sha256:77c3bfe65d8560487052ad55c6998a04b654c2fbc36d546aef2b2e511e760971",
-                "sha256:9537eecf179f566fd1c160a2e912ca0b8e02d773af0a7a1120ad4f7507cd0d26",
-                "sha256:9acdf933c1fd263c513a2df3dceecea6f3ff4419d80bf238510976bf9bcb26cd",
-                "sha256:ae0975f42ab1f28364dcda3dde3cf6c1ddab3e1d4b2909da0cb0191fa9ca0480",
-                "sha256:b3af02ecc999c8003e538e60c89a2b37646b39b688d4e44d7373e11c2debabec",
-                "sha256:b6ff59cee96b454516e47e7721098e6ceebef435e3e21ac2d6c3b8b02628eb77",
-                "sha256:b765ed3930b92812aa698a455847141869ef755a87e099fddd4ccf9d81fffb57",
-                "sha256:c98c5ffd7d41611407a1103ae11c8b634ad6a43606eca3e2a5a269e5d6e8eb07",
-                "sha256:cf7eb6b1025d3e169989416b1adcd676624c2dbed9e3bcb7137f51bfc8cc2572",
-                "sha256:d92350c22b150c1cae7ebb0ee8b5670cc84848f6359cf6b5d8f86617098a9b73",
-                "sha256:e422c3152921cece8b6a2fb6b0b4d73b6579bd20ae075e7d15143e711f3ca2ca",
-                "sha256:e840f552a509e3380b0f0ec977e8124d0dc34dc0e68289ca28f4d7c1d0d79474",
-                "sha256:f3d0a94ad151870978fb93538e95411c83899c9dc63e6fb65542f769568ecfa5"
+                "sha256:1598a6de323508cfeed6b7cd6c4efb43324f4692e20d1f76e1feec7f59013448",
+                "sha256:1b0ece94018ae21163d1f651b527156e1f03943b986188dd81bc7e066eae9d1c",
+                "sha256:2e40be731ad618cb4974d5ba60d373cdf4f1b8dcbf1dcf4d9dff5e212baf69c5",
+                "sha256:4ba59db1fcc27ea31368af524dcf874d9277f21fd2e1f7f1e2e0c75ee61419ed",
+                "sha256:59ca9c6592da581a03d42cc4e270732552243dc45e87248aa8d636d53812f6a5",
+                "sha256:5e0feb76849ca3e83dd396254e47c7dba65b3fa9ed3df67c2556293ae3e16de3",
+                "sha256:6d205249a0293e62bbb3898c4c2e1ff8a22f98375a34775a259a0523111a8f6c",
+                "sha256:6fcc5a3990e269f86d388f165a089259893851437b904f422d301cdce4ff25c8",
+                "sha256:82847f2765835c8e5308f136bc34018d09b49037ec23ecc42b246424c767056b",
+                "sha256:87902e5c03355335fc5992a74ba0247a70d937f326d852fc613b7f53516c0963",
+                "sha256:9ab21d1cb156a620d3999dd92f7d1c86824c622873841d6b080ca5495fa10fef",
+                "sha256:a1baa1dc8ecd88fb2d2a651671a84b9938461e8a8eed13e2f0a812a94084d1fa",
+                "sha256:a244f7af80dacf21054386539699ce29bcc64796ed9850c99a34b41305630286",
+                "sha256:a35af656a7ba1d3decdd4fae5322b87277de8ac98b7d9da657d9e212ece76a61",
+                "sha256:b1fe1a6f3a6f355f6c29789b5927f8bd4f134a4bd9a781099a7c4f66af8850f5",
+                "sha256:b5ad0adb51b2dee7d0ee75a69e9871e2ddfb061c73ea8bc439376298141f77f5",
+                "sha256:ba3c7a2814ec8a176bb71f91478293d633c08582119e713a0c5351c0f77698da",
+                "sha256:cd77d58fb2acf57c1d1ee2835567cd70e6f1835e32090538f17f8a3a99e5e34b",
+                "sha256:cdb3a70285e8220875e4d2bc394e49b4988bdb1298ffa4e0bd81b2f613be397c",
+                "sha256:deb529c40c3f1e38d53d5ae6cd077c21f1d49e13afc7936f7f868455e16b64a0",
+                "sha256:e7894793e6e8540dbeac77c87b489e331947813511108ae097f1715c018b8f3d"
             ],
-            "version": "==1.18.1"
+            "version": "==1.18.2"
         },
         "oauth2client": {
             "hashes": [
@@ -348,27 +348,35 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:23e177d43e4bf68950b0f8788b6a2fef2f478f4ec94883acb627b9264522a98a",
-                "sha256:2530aea4fe46e8df7829c3f05e0a0f821c893885d53cb8ac9b89cc67c143448c",
-                "sha256:303827f0bb40ff610fbada5b12d50014811efcc37aaf6ef03202dc3054bfdda1",
-                "sha256:3b019e3ea9f5d0cfee0efabae2cfd3976874e90bcc3e97b29600e5a9b345ae3d",
-                "sha256:3c07765308f091d81b6735d4f2242bb43c332cc3461cae60543df6b10967fe27",
-                "sha256:5036d4009012a44aa3e50173e482b664c1fae36decd277c49e453463798eca4e",
-                "sha256:6f38969e2325056f9959efbe06c27aa2e94dd35382265ad0703681d993036052",
-                "sha256:74a470d349d52b9d00a2ba192ae1ee22155bb0a300fd1ccb2961006c3fa98ed3",
-                "sha256:7d77034e402165b947f43050a8a415aa3205abfed38d127ea66e57a2b7b5a9e0",
-                "sha256:7f9a509f6f11fa8b9313002ebdf6f690a7aa1dd91efd95d90185371a0d68220e",
-                "sha256:942b5d04762feb0e55b2ad97ce2b254a0ffdd344b56493b04a627266e24f2d82",
-                "sha256:a9fbe41663416bb70ed05f4e16c5f377519c0dc292ba9aa45f5356e37df03a38",
-                "sha256:d10e83866b48c0cdb83281f786564e2a2b51a7ae7b8a950c3442ad3c9e36b48c",
-                "sha256:e2140e1bbf9c46db9936ee70f4be6584d15ff8dc3dfff1da022d71227d53bad3"
+                "sha256:04fe02d492d917bbdf314f63517616c1cc7ac7c25495f322c7df5745583bf548",
+                "sha256:137afc43ce7bd19b129dd0211177d03307080a728072e0a474de113ffec7f3c9",
+                "sha256:1a96b3e5172f194036d384fd9e853cbf94c42ec13bfebceb1eb0175c96f4e5d3",
+                "sha256:37d2b9f7301177e7ba2de1ab8be929a0e2625821d1d21de5f2f2eddfa16742b4",
+                "sha256:3c76643abfe83f4f3a107d06bea64d4cf702afc97a7f3a3c54275f48c7378c54",
+                "sha256:4269c698d3f76889520b9e022702c975b5b19a63705a2e098694f5f8719c7287",
+                "sha256:4d4af03db48a9b292f700c4d5df52645e5a59046800594c46e53b0518ecf3ade",
+                "sha256:7034fd811df432465fe2fec64637db84600b5f1d0e9d1123195360e2f9bf4b7d",
+                "sha256:76334ba36aa42f93b6b47b79cbc32187d3a178a4ab1c3a478c8f4198bcd93a73",
+                "sha256:852cac070c0928a2374854df312ba655533ff324bd0edc9b36d89adbc7b90263",
+                "sha256:9464f4ff95fd8f4c4a5245819e353052a0c501dd2fb027b294b005ed25f4d992",
+                "sha256:dac3bf7495c7ce6a72dff2158c8ead0f377832491a672145829ac06d64782192",
+                "sha256:e0e752699b4be387783506d34f12bef063b76ce1695aabfb0cd15bde82a3a5a7",
+                "sha256:e462ca4a59daea2ba73ac87186d638d7a43a86ec063705cf9cd215b0fafa8c0e"
             ],
-            "version": "==1.0.1"
+            "version": "==1.0.2"
         },
         "pipelineinfrastructure": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",
             "ref": "d194d601a333a27ef78fe8505aafca83894679af"
+        },
+        "plotly": {
+            "hashes": [
+                "sha256:b6b1e13e7f04dc9a9f714ab8ecc63d00a4207a736c9835912c96b6884002be1e",
+                "sha256:e6eab2b6010921f5fb998860125b90748e581de66ebc6107b686829417d98fc4"
+            ],
+            "index": "pypi",
+            "version": "==4.5.4"
         },
         "protobuf": {
             "hashes": [
@@ -392,6 +400,23 @@
                 "sha256:fdfb6ad138dbbf92b5dbea3576d7c8ba7463173f7d2cb0ca1bd336ec88ddbd80"
             ],
             "version": "==3.11.3"
+        },
+        "psutil": {
+            "hashes": [
+                "sha256:1413f4158eb50e110777c4f15d7c759521703bd6beb58926f1d562da40180058",
+                "sha256:298af2f14b635c3c7118fd9183843f4e73e681bb6f01e12284d4d70d48a60953",
+                "sha256:60b86f327c198561f101a92be1995f9ae0399736b6eced8f24af41ec64fb88d4",
+                "sha256:685ec16ca14d079455892f25bd124df26ff9137664af445563c1bd36629b5e0e",
+                "sha256:73f35ab66c6c7a9ce82ba44b1e9b1050be2a80cd4dcc3352cc108656b115c74f",
+                "sha256:75e22717d4dbc7ca529ec5063000b2b294fc9a367f9c9ede1f65846c7955fd38",
+                "sha256:a02f4ac50d4a23253b68233b07e7cdb567bd025b982d5cf0ee78296990c22d9e",
+                "sha256:d008ddc00c6906ec80040d26dc2d3e3962109e40ad07fd8a12d0284ce5e0e4f8",
+                "sha256:d84029b190c8a66a946e28b4d3934d2ca1528ec94764b180f7d6ea57b0e75e26",
+                "sha256:e2d0c5b07c6fe5a87fa27b7855017edb0d52ee73b71e6ee368fae268605cc3f5",
+                "sha256:f344ca230dd8e8d5eee16827596f1c22ec0876127c28e800d7ae20ed44c4b310"
+            ],
+            "index": "pypi",
+            "version": "==5.7.0"
         },
         "pyasn1": {
             "hashes": [
@@ -494,7 +519,14 @@
                 "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
                 "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
+            "index": "pypi",
             "version": "==2.23.0"
+        },
+        "retrying": {
+            "hashes": [
+                "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"
+            ],
+            "version": "==1.3.3"
         },
         "rsa": {
             "hashes": [

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -404,6 +404,8 @@ if __name__ == "__main__":
             fig.write_image(f"{output_dir}/graphs/season_distribution_{cc.analysis_file_key}.png", scale=IMG_SCALE_FACTOR)
 
     log.info("Graphing pie chart of normal codes for gender...")
+    # TODO: Gender is hard-coded here for COVID19. If we need this in future, but don't want to extend to other
+    #       demographic variables, then this will need to be controlled from configuration
     gender_distribution = demographic_distributions["gender"]
     normal_gender_distribution = []
     for code in CodeSchemes.GENDER.codes:
@@ -419,6 +421,8 @@ if __name__ == "__main__":
 
     log.info("Graphing normal themes by gender...")
     # Adapt the theme distributions produced above to extract the normal RQA + gender codes, and graph by gender
+    # TODO: Gender is hard-coded here for COVID19. If we need this in future, but don't want to extend to other
+    #       demographic variables, then this will need to be controlled from configuration
     for plan in PipelineConfiguration.RQA_CODING_PLANS:
         episode = episodes[plan.raw_field]
         normal_themes = dict()
@@ -437,14 +441,23 @@ if __name__ == "__main__":
                 normal_by_gender.append({
                     "RQA Theme": theme,
                     "Gender": gender_code.string_value,
-                    "Number of Participants": demographic_counts[f"gender:{gender_code.string_value}"]
+                    "Number of Participants": demographic_counts[f"gender:{gender_code.string_value}"],
+                    "Fraction of Relevant Participants":
+                        demographic_counts[f"gender:{gender_code.string_value}"] /
+                        episode["Total Relevant Participants"][f"gender:{gender_code.string_value}"]
                 })
 
         fig = px.bar(normal_by_gender, x="RQA Theme", y="Number of Participants", color="Gender", barmode="group",
                      template="plotly_white")
-        fig.update_layout(title_text=f"{plan.raw_field} by gender")
+        fig.update_layout(title_text=f"{plan.raw_field} by gender (absolute)")
         fig.update_xaxes(tickangle=-60)
         fig.write_image(f"{output_dir}/graphs/{plan.raw_field}_by_gender_absolute.png", scale=IMG_SCALE_FACTOR)
+
+        fig = px.bar(normal_by_gender, x="RQA Theme", y="Fraction of Relevant Participants", color="Gender", barmode="group",
+                     template="plotly_white")
+        fig.update_layout(title_text=f"{plan.raw_field} by gender (normalised)")
+        fig.update_xaxes(tickangle=-60)
+        fig.write_image(f"{output_dir}/graphs/{plan.raw_field}_by_gender_normalised.png", scale=IMG_SCALE_FACTOR)
 
     if pipeline_configuration.drive_upload is not None:
         log.info("Uploading CSVs to Drive...")

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from glob import glob
 
 import altair
+import plotly.express as px
 from core_data_modules.cleaners import Codes
 from core_data_modules.data_models.code_scheme import CodeTypes
 from core_data_modules.logging import Logger
@@ -394,15 +395,22 @@ if __name__ == "__main__":
                         if ind[f"{cc.analysis_file_key}{code.string_value}"] == Codes.MATRIX_1:
                             label_counts[code.string_value] += 1
 
-            chart = altair.Chart(
-                altair.Data(values=[{"label": k, "count": v} for k, v in label_counts.items()])
-            ).mark_bar().encode(
-                x=altair.X("label:N", title="Label", sort=list(label_counts.keys())),
-                y=altair.Y("count:Q", title="Number of Individuals")
-            ).properties(
-                title=f"Season Distribution: {cc.analysis_file_key}"
-            )
-            chart.save(f"{output_dir}/graphs/season_distribution_{cc.analysis_file_key}.png", scale_factor=IMG_SCALE_FACTOR)
+            data = [{"label": k, "count": v} for k, v in label_counts.items()]
+            fig = px.bar(data, x="label", y="count")
+            fig.update_layout(plot_bgcolor="white", title_text=f"Season Distribution: {cc.analysis_file_key}")
+            fig.update_xaxes(title_text="Label", showgrid=False, tickangle=0, linecolor="#aaa")
+            fig.update_yaxes(title_text="Number of Individuals", gridcolor="#aaa", linecolor="#aaa")
+            fig.write_image(f"{output_dir}/graphs/season_distribution_{cc.analysis_file_key}.png", scale=IMG_SCALE_FACTOR)
+
+            # chart = altair.Chart(
+            #     altair.Data(values=[{"label": k, "count": v} for k, v in label_counts.items()])
+            # ).mark_bar().encode(
+            #     x=altair.X("label:N", title="Label", sort=list(label_counts.keys())),
+            #     y=altair.Y("count:Q", title="Number of Individuals")
+            # ).properties(
+            #     title=f"Season Distribution: {cc.analysis_file_key}"
+            # )
+            # chart.save(f"{output_dir}/graphs/season_distribution_{cc.analysis_file_key}.png", scale_factor=IMG_SCALE_FACTOR)
 
     if pipeline_configuration.drive_upload is not None:
         log.info("Uploading CSVs to Drive...")

--- a/generate_analysis_graphs.py
+++ b/generate_analysis_graphs.py
@@ -397,10 +397,9 @@ if __name__ == "__main__":
                             label_counts[code.string_value] += 1
 
             data = [{"Label": k, "Number of Participants": v} for k, v in label_counts.items()]
-            fig = px.bar(data, x="Label", y="Number of Participants", template="plotly_white")
-            fig.update_layout(plot_bgcolor="white", title_text=f"Season Distribution: {cc.analysis_file_key}")
-            fig.update_xaxes(title_text="Label", showgrid=False, tickangle=-60)
-            fig.update_yaxes(title_text="Number of Participants")
+            fig = px.bar(data, x="Label", y="Number of Participants", template="plotly_white",
+                         title=f"Season Distribution: {cc.analysis_file_key}")
+            fig.update_xaxes(tickangle=-60)
             fig.write_image(f"{output_dir}/graphs/season_distribution_{cc.analysis_file_key}.png", scale=IMG_SCALE_FACTOR)
 
     log.info("Graphing pie chart of normal codes for gender...")


### PR DESCRIPTION
Adds 3 new types of graph:
 - A graph showing the distribution of normal codes for RQA, disaggregated by gender:
    - as absolute numbers
    - as fractions of the number of people who mentioned that theme out of all the people with that gender.
 - A pie chart of gender.

I needed to switch away from altair to do this, because it couldn't support all of the above, so the new graphs are now being rendered with plotly. Plotly's API is easier to use and more capable, so the graphing code is now a little shorter and more readable, especially for the new graphs.

This PR also migrates the existing RQA distribution graph from altair to plotly to show what needs to change to convert existing graphs to use the new library. The remaining graphs will be migrated and the dependency on altair removed in a future PR.

Examples of all the new/changed graphs can be found here: https://drive.google.com/drive/folders/1ftPHrliUk1LpaMtVY4k7wXgLiaI4FAyK?usp=sharing