### PR TITLE
Switch to the OCHA/ROSEA map for counties, and add project licence

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,32 @@
+MIT License
+
+Copyright (c) 2020 Africa's Voices Foundation (AVF)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+3RD PARTY EXCEPTIONS
+
+The geometry data for Kenya is a resdistribution of a dataset from OCHA ROSEA, 
+with feature properties modified by Africa's Voices Foundation. Those files, along
+with their source and licence, are:
+
+- `geojson/kenya_counties.geojson`: Adapted from data produced by OCHA ROSEA.
+Retrieved from https://data.humdata.org/dataset/ken-administrative-boundaries
+March 2020. Licence "Other: humanitarian use only"

--- a/LICENCE
+++ b/LICENCE
@@ -23,7 +23,7 @@ SOFTWARE.
 
 3RD PARTY EXCEPTIONS
 
-The geometry data for Kenya is a resdistribution of a dataset from OCHA ROSEA, 
+The geometry data for Kenya is a redistribution of a dataset from OCHA ROSEA,
 with feature properties modified by Africa's Voices Foundation. Those files, along
 with their source and licence, are:
 

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -342,7 +342,7 @@ if __name__ == "__main__":
         if code.code_type == CodeTypes.NORMAL:
             county_frequencies[code.string_value] = demographic_distributions["county"][code.string_value]
 
-    MappingUtils.plot_frequency_map(counties_map, "avf_id", county_frequencies)
+    MappingUtils.plot_frequency_map(counties_map, "ADM1_AVF", county_frequencies)
     plt.savefig(f"{output_dir}/maps/county_total_participants.png", dpi=1200, bbox_inches="tight")
     plt.close()
 
@@ -356,7 +356,7 @@ if __name__ == "__main__":
                 if county_code.code_type == CodeTypes.NORMAL:
                     rqa_total_county_frequencies[county_code.string_value] = \
                         episode["Total Relevant Participants"][f"county:{county_code.string_value}"]
-            MappingUtils.plot_frequency_map(counties_map, "avf_id", rqa_total_county_frequencies)
+            MappingUtils.plot_frequency_map(counties_map, "ADM1_AVF", rqa_total_county_frequencies)
             plt.savefig(f"{output_dir}/maps/county_{cc.analysis_file_key}_1_total_relevant.png",
                         dpi=1200, bbox_inches="tight")
             plt.close()
@@ -377,7 +377,7 @@ if __name__ == "__main__":
                         theme_county_frequencies[county_code.string_value] = \
                             demographic_counts[f"county:{county_code.string_value}"]
 
-                MappingUtils.plot_frequency_map(counties_map, "avf_id", theme_county_frequencies)
+                MappingUtils.plot_frequency_map(counties_map, "ADM1_AVF", theme_county_frequencies)
                 plt.savefig(f"{output_dir}/maps/county_{cc.analysis_file_key}_{map_index}_{code.string_value}.png",
                             dpi=1200, bbox_inches="tight")
                 plt.close()

--- a/src/mapping_utils.py
+++ b/src/mapping_utils.py
@@ -53,5 +53,5 @@ class MappingUtils(object):
         # TODO: Modify once per-map configuration needs are better understood by testing on other maps.
         for i, admin_region in geo_data.iterrows():
             plt.annotate(s=frequencies[admin_region[admin_id_column]],
-                         xy=(admin_region.label_x, admin_region.label_y),
+                         xy=(admin_region.ADM1_LX, admin_region.ADM1_LY),
                          ha='center', va="center", fontsize=3.8)


### PR DESCRIPTION
Sample outputs: https://drive.google.com/drive/folders/1mkhqiaeLhgAYo622FKTJEH7MhWGbde3n?usp=sharing. 

The main visible difference between this and #35  is the increased detail on the coastline. The properties that we added for avf ids and label positions have been updated to take the same format as OCHA uses, which is  'ADM1_{property}'. All properties have 10 characters maximum due to a limitation in the spec for shapefiles. Some coastal county labels were repositioned slightly to account for the new border.

I've also attempted to explain the exception to MIT for the geodata. Please review carefully and let me know if I've done the right thing.