### PR TITLE
Add Legend to Maps

### DIFF
--- a/src/mapping_utils.py
+++ b/src/mapping_utils.py
@@ -56,7 +56,7 @@ class MappingUtils(object):
         colors = []
         for i, admin_region in geo_data.iterrows():
             frequency = frequencies[admin_region[admin_id_column]]
-            bin_id = [i for i, z in enumerate(bin_edges) if z >= frequency][0]  # Index of first bin edge >= frequency
+            bin_id = [i for i, b in enumerate(bin_edges) if b >= frequency][0]  # Index of first bin edge >= frequency
             colors.append(cls.AVF_COLOR_MAP(float(bin_id) / number_of_classes))
 
         # Plot the choropleth map.


### PR DESCRIPTION
Sample outputs here: https://drive.google.com/drive/folders/1eRqZfRfmBal4ZgZd7ljL70HQ5PZjw2l-?usp=sharing

Located in the lower-right corner for now. This should work for both Kenya and Somalia due to the shape of both countries, but we may need to do some work on placement in future.

I needed to pull the choropleth colour calculation out of geodata.plot() and run it explicitly so I had the colour bins available to create the legend. I think this actually helps the readability of the code, because it highlights the edge cases when classifying rather than switching between different plotting modes.