### PR TITLE
Add zoomed map of Nairobi to constituencies

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -451,6 +451,9 @@ if __name__ == "__main__":
 
     fig, ax = plt.subplots()
     MappingUtils.plot_frequency_map(constituencies_map, "ADM2_AVF", constituency_frequencies, ax=ax)
+    MappingUtils.plot_inset_frequency_map(
+        constituencies_map, "ADM2_AVF", constituency_frequencies,
+        inset_region=(36.62, -1.46, 37.12, -1.09), zoom=3, inset_position=(35.60, -2.95), ax=ax)
     MappingUtils.plot_water_bodies(lakes_map, ax=ax)
     plt.savefig(f"{output_dir}/maps/constituency_total_participants.png", dpi=1200, bbox_inches="tight")
     plt.close(fig)
@@ -468,6 +471,9 @@ if __name__ == "__main__":
 
             fig, ax = plt.subplots()
             MappingUtils.plot_frequency_map(constituencies_map, "ADM2_AVF", rqa_total_constituency_frequencies, ax=ax)
+            MappingUtils.plot_inset_frequency_map(
+                constituencies_map, "ADM2_AVF", rqa_total_constituency_frequencies,
+                inset_region=(36.62, -1.46, 37.12, -1.09), zoom=3, inset_position=(35.60, -2.95), ax=ax)
             MappingUtils.plot_water_bodies(lakes_map, ax=ax)
             plt.savefig(f"{output_dir}/maps/constituency_{cc.analysis_file_key}_1_total_relevant.png",
                         dpi=1200, bbox_inches="tight")
@@ -491,6 +497,9 @@ if __name__ == "__main__":
 
                 fig, ax = plt.subplots()
                 MappingUtils.plot_frequency_map(constituencies_map, "ADM2_AVF", theme_constituency_frequencies, ax=ax)
+                MappingUtils.plot_inset_frequency_map(
+                    constituencies_map, "ADM2_AVF", theme_constituency_frequencies,
+                    inset_region=(36.62, -1.46, 37.12, -1.09), zoom=3, inset_position=(35.60, -2.95), ax=ax)
                 MappingUtils.plot_water_bodies(lakes_map, ax=ax)
                 plt.savefig(f"{output_dir}/maps/constituency_{cc.analysis_file_key}_{map_index}_{code.string_value}.png",
                             dpi=1200, bbox_inches="tight")

--- a/src/mapping_utils.py
+++ b/src/mapping_utils.py
@@ -108,7 +108,7 @@ class MappingUtils(object):
                             ha="center", va="center", fontsize=3.8)
 
     @classmethod
-    def plot_inset_map(cls, geo_data, admin_id_column, frequencies, inset_region, inset_position, zoom, ax):
+    def plot_inset_frequency_map(cls, geo_data, admin_id_column, frequencies, inset_region, inset_position, zoom, ax):
         """
         Plots a map of the given geo data with a choropleth showing the frequency of responses in each administrative
         region as an inset on another axes.

--- a/src/mapping_utils.py
+++ b/src/mapping_utils.py
@@ -42,8 +42,11 @@ class MappingUtils(object):
                                          for this feature.
                                          If None, no callout lines are drawn.
         :type callout_position_columns: (str, str) | None
+        :param show_legend: Whether to draw a legend for the choropleth. The legend will be drawn to the bottom-right
+                            corner.
+        :type show_legend: bool
         :param ax: Axes on which to draw the plot. If None, draws to a new figure.
-        :type ax: matplotlib.pyplot.Artist | None
+        :type ax: matplotlib.pyplot.Axes | None
         """
         # Class the frequencies using the Fisher-Jenks method, a standard GIS algorithm for choropleth classification.
         # Using this method prevents a region with a vastly higher frequency than the others (e.g. a capital city)
@@ -106,6 +109,25 @@ class MappingUtils(object):
 
     @classmethod
     def plot_inset_map(cls, geo_data, admin_id_column, frequencies, inset_region, inset_position, zoom, ax):
+        """
+        Plots a map of the given geo data with a choropleth showing the frequency of responses in each administrative
+        region as an inset on another axes.
+
+        :param geo_data: GeoData to plot.
+        :type geo_data: geopandas.GeoDataFrame
+        :param admin_id_column: Column in `geo_data` of the administrative region ids.
+        :type admin_id_column: str
+        :param frequencies: Dictionary of admin_id -> frequency.
+        :type frequencies: dict of str -> int
+        :param inset_region: Map co-ordinates to plot in the inset map, in the form (x1, y1, x2, y2).
+        :type inset_region: (float, float, float, float)
+        :param inset_position: Map co-ordinates to center the inset on, in the form (x, y).
+        :type inset_position: (float, float)
+        :param zoom: Zoom factor.
+        :type zoom: float
+        :param ax: Axes on which to draw the plot. If None, draws to a new figure.
+        :type ax: matplotlib.pyplot.Axes
+        """
         inset_ax = zoomed_inset_axes(ax, zoom=zoom, loc="center", bbox_to_anchor=inset_position,
                                      bbox_transform=ax.transData)
         plt.setp(inset_ax.spines.values(), linewidth=0.2, color="black")


### PR DESCRIPTION
Sample outputs here: https://drive.google.com/drive/folders/1zKwkk-1yTv3OrwYn61Qy5u4FP-gKwZ2V?usp=sharing

The objective here is to show the smallest constituencies in Nairobi in a similar size to those in the Western counties of the main map, not to put a particular emphasis on Nairobi itself. As a result, they're still small and require zooming, but that's inevitable when showing 290 constituencies. It's now easy for us to prepare localised maps showing just a few constituencies should projects request it.
