### PR TITLE
Use AnalysisUtils to compute Repeat Participation

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -128,32 +128,36 @@ if __name__ == "__main__":
     repeat_participations = OrderedDict()
     for i in range(1, len(PipelineConfiguration.RQA_CODING_PLANS) + 1):
         repeat_participations[i] = {
-            "Episodes Participated In": i,
-            "Number of Individuals": 0,
-            "% of Individuals": None
+            "Number of Episodes Participated In": i,
+            "Number of Participants with Opt-Ins": 0,
+            "% of Participants with Opt-Ins": None
         }
 
     # Compute the number of individuals who participated each possible number of times, from 1 to <number of RQAs>
     # An individual is considered to have participated if they sent a message and didn't opt-out, regardless of the
     # relevance of any of their messages.
     for ind in individuals:
-        if ind["consent_withdrawn"] == Codes.FALSE:
-            weeks_participated = 0
-            for plan in PipelineConfiguration.RQA_CODING_PLANS:
-                if plan.raw_field in ind:
-                    weeks_participated += 1
-            assert weeks_participated != 0, f"Found individual '{ind['uid']}' with no participation in any week"
-            repeat_participations[weeks_participated]["Number of Individuals"] += 1
+        if AnalysisUtils.withdrew_consent(ind, CONSENT_WITHDRAWN_KEY):
+            continue
+
+        weeks_participated = 0
+        for plan in PipelineConfiguration.RQA_CODING_PLANS:
+            if AnalysisUtils.opt_in(ind, CONSENT_WITHDRAWN_KEY, plan):
+                weeks_participated += 1
+        assert weeks_participated != 0, f"Found individual '{ind['uid']}' with no participation in any week"
+        repeat_participations[weeks_participated]["Number of Participants with Opt-Ins"] += 1
 
     # Compute the percentage of individuals who participated each possible number of times.
-    # Percentages are computed after excluding individuals who opted out.
-    total_individuals = len([td for td in individuals if td["consent_withdrawn"] == Codes.FALSE])
+    # Percentages are computed out of the total number of participants who opted-in.
+    total_individuals = len(AnalysisUtils.filter_opt_ins(
+        individuals, CONSENT_WITHDRAWN_KEY, PipelineConfiguration.RQA_CODING_PLANS))
     for rp in repeat_participations.values():
-        rp["% of Individuals"] = round(rp["Number of Individuals"] / total_individuals * 100, 1)
+        rp["% of Participants with Opt-Ins"] = round(rp["Number of Participants with Opt-Ins"] / total_individuals * 100, 1)
 
     # Export the participation frequency data to a csv
     with open(f"{output_dir}/repeat_participations.csv", "w") as f:
-        headers = ["Episodes Participated In", "Number of Individuals", "% of Individuals"]
+        headers = ["Number of Episodes Participated In", "Number of Participants with Opt-Ins",
+                   "% of Participants with Opt-Ins"]
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()
 


### PR DESCRIPTION
Also renames individuals -> participants with opt-ins for consistency with other analysis files. Adapted from an unmerged branch on OCHA